### PR TITLE
fix Network with PRA

### DIFF
--- a/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/RaoRunnerService.java
+++ b/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/RaoRunnerService.java
@@ -59,6 +59,7 @@ public class RaoRunnerService {
         try {
             Instant computationStartInstant = Instant.now();
             RaoResult raoResult = raoRunnerProvider.run(getRaoInput(raoRequest, network, crac), raoParameters);
+            network = fileImporter.importNetwork(raoRequest.getNetworkFileUrl());
             eventsLogger.info("Applying remedial actions for preventive state");
             applyRemedialActionsForState(network, raoResult, crac.getPreventiveState());
             return saveResultsAndCreateRaoResponse(raoRequest, crac, raoResult, network, computationStartInstant, raoParameters);
@@ -114,6 +115,7 @@ public class RaoRunnerService {
 
     private static void applyRemedialActionsForState(Network network, RaoResult raoResult, State state) {
         raoResult.getActivatedNetworkActionsDuringState(state).forEach(networkAction -> networkAction.apply(network));
-        raoResult.getOptimizedSetPointsOnState(state).forEach((rangeAction, setPoint) -> rangeAction.apply(network, setPoint));
+        raoResult.getActivatedRangeActionsDuringState(state).forEach(rangeAction ->
+            rangeAction.apply(network, raoResult.getOptimizedSetPointsOnState(state).get(rangeAction)));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
- Network with PRA is generated using the same object that was passed to the RAO
- Not only activated range actions but all available range actions are applied on the network. While this has no importance most of the time (the optimized setpoint for unactivated range actions is equal to its initial setpoint, so applying it has no effect on the network), it does have an effect on HVDC RAs. When an HVDC RA is applied in CASTOR, AC emulation is disabled immediately.


**What is the new behavior (if this is a feature change)?**
- Network is re-imported from initial iidm before applying PRAs
- Only activated range actions are applied. Thus HVDC AC emulation is not disabled if it was enabled in the initial network, and if no HVDC PRA was chosen by the RAO.
