### PR TITLE
Fix interruption by using runId and common stop exchange

### DIFF
--- a/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/RaoRunnerListener.java
+++ b/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/RaoRunnerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -76,7 +76,7 @@ public class RaoRunnerListener implements MessageListener {
             addMetaDataToLogsModelContext(raoRequest.getId(), brokerCorrelationId, message.getMessageProperties().getAppId(), raoRequest.getEventPrefix());
             final GenericThreadLauncher<RaoRunnerService, AbstractRaoResponse> launcher = new GenericThreadLauncher<>(
                 raoRunnerService,
-                raoRequest.getId(),
+                raoRequest.getRunId(),
                 MDC.getCopyOfContextMap(),
                 raoRequest
             );

--- a/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/StopService.java
+++ b/rao-runner-app/src/main/java/com/farao_community/farao/rao_runner/app/StopService.java
@@ -1,23 +1,33 @@
 /*
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package com.farao_community.farao.rao_runner.app;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
 public class StopService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StopService.class);
 
-    public void stop(final String taskId) {
-        Optional<Thread> thread = isRunning(taskId);
-        while (thread.isPresent()) {
-            thread.get().interrupt();
-            thread = isRunning(taskId);
+    public void stop(final String runId) {
+        LOGGER.info("Received stop request for run id {}", runId);
+        Optional<Thread> thread = isRunning(runId);
+        if (thread.isPresent()) {
+            LOGGER.info("Run has been found, stopping it");
+            while (thread.isPresent()) {
+                thread.get().interrupt();
+                thread = isRunning(runId);
+            }
+            LOGGER.info("Computation for run id {} has been successfully stopped", runId);
+        } else {
+            LOGGER.info("Computation for run id {} has not been found", runId);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Aligned internal process identification for launching and stopping operations, ensuring more consistent behavior.
	- Enhanced logging during termination procedures to improve tracking and transparency of ongoing computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->